### PR TITLE
feat: Add metadata.test_failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@
     - [eventUpdates](#eventupdates)
       - [Example](#example-3)
 - [Changelog](#changelog)
+  - [v1.12.0](#v1120)
+  - [v1.11.0](#v1110)
   - [v1.10.0](#v1100)
   - [v1.9.0](#v190)
   - [v1.8.0](#v180)
@@ -106,6 +108,9 @@ Metadata has the following attributes:
   * **commits_since_annotated_tag** *Optional* number of commits since the last annotated tag.
 * **source_location** *Optional* path and line number of the source file that was recorded. Most commonly, this is the test case that was recorded. Format is `<path>:<line>`, with `line` being optional.
 * **test_status** *Optional* status of the test that ran to generate the AppMap. Valid values are `succeeded` or `failed`.
+* **test_failure** *Optional* Details about a failed test.
+  * **message** *Required* Assertion failure message or exception message.
+  * **location** *Optional* Path and line number where the assertion failed or the exception was raised. Format is `<path>:<line>`, with `line` being optional.
 * **exception** *Optional* unhandled exception which occurred during scenairo processing.
   * **class** *Required* exception class name.
   * **message** *Optional* exception message.
@@ -598,8 +603,11 @@ that should be used in place of the original event.
 ```
 # Changelog
 
+## v1.12.0
+* Add `metadata.test_failure` to provide the failed test assertion and its location.
+
 ## v1.11.0
-* Add `items` to parameter object format to describe array-like elements
+* Add `items` to parameter object format to describe array-like elements.
 
 ## v1.10.0
 * Parameter object `properties` can be nested.

--- a/README.md
+++ b/README.md
@@ -108,9 +108,9 @@ Metadata has the following attributes:
   * **commits_since_annotated_tag** *Optional* number of commits since the last annotated tag.
 * **source_location** *Optional* path and line number of the source file that was recorded. Most commonly, this is the test case that was recorded. Format is `<path>:<line>`, with `line` being optional.
 * **test_status** *Optional* status of the test that ran to generate the AppMap. Valid values are `succeeded` or `failed`.
-* **test_failure** *Optional* Details about a failed test.
-  * **message** *Required* Assertion failure message or exception message.
-  * **location** *Optional* Path and line number where the assertion failed or the exception was raised. Format is `<path>:<line>`, with `line` being optional.
+* **test_failure** *Optional* details about a failed test.
+  * **message** *Required* assertion failure message or exception message.
+  * **location** *Optional* path and line number where the assertion failed or the exception was raised. Format is `<path>:<line>`, with `line` being optional.
 * **exception** *Optional* unhandled exception which occurred during scenairo processing.
   * **class** *Required* exception class name.
   * **message** *Optional* exception message.
@@ -136,6 +136,11 @@ Metadata has the following attributes:
   },
   "recorder": {
     "name": "rspec"
+  },
+  "test_status": "failed",
+  "test_failure": {
+      "message": "Expected true to be nil or false",
+      "location": "spec/login_spec.rb:34"
   },
   "git": {
     "repository": "https://github.com/applandinc/appmap",


### PR DESCRIPTION
When a test fails, provide `metadata.test_failure` to indicate:

a) The failed assertion message
b) Location of the failed assertion

This may sometimes be, but is not always, somewhat redundant with `metadata.exception`, because test runners will sometimes catch and handle assertion errors before AppMap sees them. Also, this new field provides a definitive place for client tools to find the test failure details.