### PR TITLE
feat: Add code recording to the spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Metadata has the following attributes:
   * **url** *Required* unique URL of the client.
   * **version** *Optional* version of the client.
 * **recorder** *Required* information about the method which was used by the client to record the scenario.
-  * **type** *Required* type of the recording method. Should be consistent across languages and clients. Options: `tests, requests, remote, process`.
+  * **type** *Required* type of the recording method. Should be consistent across languages and clients. Options: `tests, requests, remote, process, code`.
   * **name** *Required* name of the recording method. This name must be unique to the client, but need not be unique across different clients.
 * **recording** *Optional* information about the entry-point function which was recorded.
   * **defined_class** *Required* name of the class which defines the entry-point function.


### PR DESCRIPTION
Code block recording can specify `code` as the recorder type.